### PR TITLE
Upgrade to trifecta 1.6

### DIFF
--- a/src/Network/URI/Template/Parser.hs
+++ b/src/Network/URI/Template/Parser.hs
@@ -95,6 +95,6 @@ uriTemplate = spaces *> many (literal <|> embed)
 
 parseTemplate :: String -> Either Doc UriTemplate
 parseTemplate t = case parseString uriTemplate mempty t of
-                        Failure err -> Left err
+                        Failure err -> Left (_errDoc err)
                         Success r -> Right r
 

--- a/uri-templater.cabal
+++ b/uri-templater.cabal
@@ -25,7 +25,7 @@ library
                      Network.URI.Template.Parser,
                      Network.URI.Template.Internal
   build-depends:     base <5,
-                     trifecta,
+                     trifecta >=1.6,
                      charset,
                      parsers,
                      template-haskell,


### PR DESCRIPTION
It is not backwards compatible with 1.5.x.

https://github.com/ekmett/trifecta/blob/v1.6/CHANGELOG.markdown#16
