### PR TITLE
Add other-extensions: TypeApplications

### DIFF
--- a/uri-templater.cabal
+++ b/uri-templater.cabal
@@ -41,6 +41,7 @@ library
                      uuid-types,
                      time
   hs-source-dirs:    src
+  other-extensions:  TypeApplications
 
 test-suite test-uri-templates
    type:             exitcode-stdio-1.0


### PR DESCRIPTION
This will prevent cabal from trying to build the package with GHC which don't know TypeApplications.

I made revisions on hackage for current release.