### PR TITLE
Switch from ansi-wl-pprint to prettyprinter

### DIFF
--- a/src/Network/URI/Template/Parser.hs
+++ b/src/Network/URI/Template/Parser.hs
@@ -5,7 +5,8 @@ import Data.List
 import Data.Monoid
 import Text.Trifecta
 import Text.Parser.Char
-import Text.PrettyPrint.ANSI.Leijen (Doc)
+import Data.Text.Prettyprint.Doc (Doc)
+import Data.Text.Prettyprint.Doc.Render.Terminal (AnsiStyle)
 import Network.URI.Template.Types
 
 range :: Char -> Char -> Parser Char
@@ -98,7 +99,7 @@ embed = between (char '{') (char '}') variables
 uriTemplate :: Parser UriTemplate
 uriTemplate = spaces *> many (literal <|> embed)
 
-parseTemplate :: String -> Either Doc UriTemplate
+parseTemplate :: String -> Either (Doc AnsiStyle) UriTemplate
 parseTemplate t =
   case parseString uriTemplate mempty t of
     Failure err -> Left (_errDoc err)

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -8,11 +8,11 @@ import Network.URI.Template
 import Network.URI.Template.TH
 import Network.URI.Template.Types
 import System.Exit
-import Text.PrettyPrint.ANSI.Leijen (Doc, renderCompact, displayS)
+import Data.Text.Prettyprint.Doc (Doc)
 import Test.HUnit hiding (test, path, Label)
 
 -- Just being lazy here
-instance Eq Doc where
+instance Eq (Doc ann) where
   (==) d1 d2 = show d1 == show d2
 
 type TestRegistry = Writer [Test]

--- a/uri-templater.cabal
+++ b/uri-templater.cabal
@@ -32,7 +32,8 @@ library
                      HTTP,
                      dlist,
                      mtl,
-                     ansi-wl-pprint,
+                     prettyprinter,
+                     prettyprinter-ansi-terminal,
                      vector,
                      containers,
                      unordered-containers,
@@ -52,4 +53,4 @@ test-suite test-uri-templates
                      uri-templater,
                      template-haskell,
                      HUnit,
-                     ansi-wl-pprint
+                     prettyprinter


### PR DESCRIPTION
I tried building this package with the latest Stackage nightly and ran into the following error:

```
.../uri-templater/src/Network/URI/Template/Parser.hs:104:26: error:
    • Found hole:
        _ :: prettyprinter-1.4.0:Data.Text.Prettyprint.Doc.Internal.Doc
               prettyprinter-ansi-terminal-1.1.1.2:Data.Text.Prettyprint.Doc.Render.Terminal.Internal.AnsiStyle
             -> Doc
    • In the expression: _
      In the first argument of ‘Left’, namely ‘(_ (_errDoc err))’
      In the expression: Left (_ (_errDoc err))
    • Relevant bindings include
        err :: ErrInfo (bound at src/Network/URI/Template/Parser.hs:104:13)
        t :: String (bound at src/Network/URI/Template/Parser.hs:102:15)
        parseTemplate :: String -> Either Doc UriTemplate
          (bound at src/Network/URI/Template/Parser.hs:102:1)
      Valid hole fits include
        mempty :: forall a. Monoid a => a
          with mempty @(prettyprinter-1.4.0:Data.Text.Prettyprint.Doc.Internal.Doc
                          prettyprinter-ansi-terminal-1.1.1.2:Data.Text.Prettyprint.Doc.Render.Terminal.Internal.AnsiStyle
                        -> Doc)
          (imported from ‘Data.Monoid’ at src/Network/URI/Template/Parser.hs:5:1-18
           (and originally defined in ‘GHC.Base’))
    |
104 |     Failure err -> Left (_ (_errDoc err))
    |
```

This PR fixes that error, but I can't really say if the changes make sense or not. 