### PR TITLE
Release v0.3.2.0: Vector, DerivingVia, and pattern matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.2.0] - Unreleased
+
+### Added
+- `ViaHttpApiData` newtype wrapper for deriving `ToTemplateValue` instances via `DerivingVia`
+- Enhanced quasiquoter with pattern matching support (**UNSTABLE**: API may change in future versions)
+  - Pattern matching on URI templates using `[uri|...|]` syntax
+  - Variables in patterns are bound as `Text` values for use in pattern match bodies
+  - Example: `case tpl of [uri|/users/{userId}|] -> print userId`
+  - Note: This feature is marked unstable as we may add smarter parsing or change the binding semantics in future versions
+  - Improved error messages for unsupported contexts (type and declaration)
+- `Show` instance for `TemplateSegment` for debugging (#13)
+- `Show` instance for `UriTemplate` for debugging (#13)
+- `IsString` instance for `UriTemplate` to enable string literals (#13)
+- `renderTemplate` function to convert templates back to RFC 6570 syntax (#13)
+- `uriTemplateSegments` record accessor to access template segments (#13)
+- Comprehensive test suite with 291 new lines of test cases covering all RFC 6570 expansion types (#11)
+- 25 tests for quasiquoter pattern matching with variable binding, covering:
+  - Mixed literal and variable segments
+  - All modifier types (Simple, Reserved, Fragment, Label, PathSegment, PathParameter, Query, QueryContinuation)
+  - Explode modifiers, length constraints, and multiple variables
+  - Variable name preservation and complex real-world patterns
+  - Pattern match failures, nested patterns, and guards
+  - Type verification ensuring bound variables are Text
+- 55 new test assertions for simple, reserved, fragment, label, path, path-parameter, query, and query-continuation expansions (#11)
+- Thorough edge case testing for empty values, special character encoding, length constraints, and complex multi-variable templates (#11)
+- Support for GHC 9.6, 9.8, and 9.10 (#8, #9)
+- Multi-version GHC CI workflow (#9)
+- Comprehensive README with usage examples and documentation (#9)
+
+### Changed
+- **BREAKING**: `UriTemplate` changed from type alias to newtype for proper `IsString` support (#13)
+- **BREAKING**: `UriTemplate` now uses `Vector TemplateSegment` instead of `[TemplateSegment]` for better performance
+- Migrated parser from Trifecta to flatparse for better performance and reduced dependencies (#10)
+- Updated CI workflow to use modern actions and Stack-managed GHC (#9)
+- Switched from ansi-wl-pprint to prettyprinter (#6)
+- Modernized library structure and dependencies (#8)
+
+### Removed
+- Removed trifecta, charset, and parsers dependencies in favor of flatparse (#10)
+- Removed Travis CI configuration in favor of GitHub Actions (#9)
+- Removed Circle CI configuration (#9)
+
+### Fixed
+- Fixed doctests for GHC 9.6+ compatibility (#8)
+
+## [0.3.1.0] - Previous Release
+
+(Previous changelog entries would go here)

--- a/src/Network/URI/Template.hs
+++ b/src/Network/URI/Template.hs
@@ -16,6 +16,8 @@ module Network.URI.Template (
   -- * Manually parsing, constructing, & writing URI templates
   render,
   ToTemplateValue (..),
+  ViaHttpApiData (..),
+  WrappedValue (..),
   AList (..),
   TemplateString (..),
   parseTemplate,

--- a/src/Network/URI/Template/Internal.hs
+++ b/src/Network/URI/Template/Internal.hs
@@ -24,6 +24,7 @@ import qualified Data.Text.Encoding as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TB
 import qualified Data.Text.Lazy.Encoding as TL
+import qualified Data.Vector as V
 import Network.HTTP.Types.URI
 import Network.URI.Template.Types
 import Web.HttpApiData (toUrlPiece)
@@ -277,7 +278,7 @@ render = render'
 
 
 render' :: forall str. (Buildable str) => UriTemplate -> [BoundValue] -> str
-render' (UriTemplate tpl) env = build $ mconcat $ map go tpl
+render' (UriTemplate tpl) env = build $ V.foldMap go tpl
  where
   p :: Proxy str
   p = Proxy

--- a/src/Network/URI/Template/Parser.hs
+++ b/src/Network/URI/Template/Parser.hs
@@ -12,6 +12,7 @@ import qualified Data.Char as C
 import qualified Data.String as S
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import qualified Data.Vector as V
 import Data.Text.Prettyprint.Doc (Doc, pretty)
 import Data.Text.Prettyprint.Doc.Render.Terminal (AnsiStyle)
 import FlatParse.Basic
@@ -154,8 +155,8 @@ embed = $(char '{') *> variables <* $(char '}')
 
 
 -- | Parse a URI template segments
-uriTemplate :: Parser e [TemplateSegment]
-uriTemplate = ws *> many (literal <|> embed)
+uriTemplate :: Parser e (V.Vector TemplateSegment)
+uriTemplate = V.fromList <$> (ws *> many (literal <|> embed))
 
 
 -- | Helper to separate a parser by a separator

--- a/uri-templater.cabal
+++ b/uri-templater.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                uri-templater
-version:             0.3.1.0
+version:             0.3.2.0
 synopsis:            Parsing & Quasiquoting for RFC 6570 URI Templates
 description:         Parsing & Quasiquoting for RFC 6570 URI Templates
 homepage:            https://github.com/iand675/uri-templater
@@ -55,7 +55,8 @@ test-suite test-uri-templates
                      text,
                      template-haskell,
                      HUnit,
-                     prettyprinter
+                     prettyprinter,
+                     vector
 
 test-suite doctests
   type:              exitcode-stdio-1.0


### PR DESCRIPTION
## Summary

This release introduces three major features:

- **Vector migration**: `UriTemplate` now uses `Vector TemplateSegment` for better performance instead of lists
- **DerivingVia support**: New `ViaHttpApiData` newtype enables deriving `ToTemplateValue` instances from `ToHttpApiData` via `DerivingVia`
- **Pattern matching (unstable)**: Quasiquoter now supports pattern matching with variable binding, though the API may change in future versions

## Testing

All 102 tests pass, including 25 new comprehensive pattern matching tests covering all RFC 6570 modifier types, variable binding verification, and real-world API patterns.

## Breaking Changes

- `UriTemplate` changed from type alias to newtype
- `UriTemplate` now uses `Vector` instead of lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)