### PR TITLE
Release version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.2.0] - Unreleased
+## [1.0.0] - 2025-11-21
 
 ### Added
 - `ViaHttpApiData` newtype wrapper for deriving `ToTemplateValue` instances via `DerivingVia`

--- a/uri-templater.cabal
+++ b/uri-templater.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                uri-templater
-version:             0.3.2.0
+version:             1.0.0
 synopsis:            Parsing & Quasiquoting for RFC 6570 URI Templates
 description:         Parsing & Quasiquoting for RFC 6570 URI Templates
 homepage:            https://github.com/iand675/uri-templater


### PR DESCRIPTION
## Summary
Bump uri-templater to version 1.0.0, marking the first stable release with structured error handling, enhanced API, and pattern matching support.

## Changes
- Updated version from 0.3.2.0 to 1.0.0 in cabal file
- Updated CHANGELOG with release date (2025-11-21)

This release includes significant improvements with comprehensive RFC 6570 compliance, vector-based performance optimizations, and detailed error reporting.