### PR TITLE
Hackage compliance fixes for 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.2.0] - Unreleased
+## [1.0.0] - 2025-11-21
 
 ### Added
 - `ViaHttpApiData` newtype wrapper for deriving `ToTemplateValue` instances via `DerivingVia`

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 Ian Duncan
+Copyright (c) 2021-2025 Ian Duncan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/uri-templater.cabal
+++ b/uri-templater.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                uri-templater
-version:             0.3.2.0
+version:             1.0.0
 synopsis:            Parsing & Quasiquoting for RFC 6570 URI Templates
 description:         Parsing & Quasiquoting for RFC 6570 URI Templates
 homepage:            https://github.com/iand675/uri-templater

--- a/uri-templater.cabal
+++ b/uri-templater.cabal
@@ -52,7 +52,7 @@ test-suite test-uri-templates
   type:              exitcode-stdio-1.0
   main-is:           Test.hs
   hs-source-dirs:    test
-  build-depends:     base,
+  build-depends:     base >= 4.9 && <5,
                      mtl,
                      uri-templater,
                      text,
@@ -68,6 +68,6 @@ test-suite doctests
   ghc-options:       -threaded
   main-is:           Doctests.hs
   hs-source-dirs:    test
-  build-depends:     base,
+  build-depends:     base >= 4.9 && <5,
                      doctest >= 0.8
   default-language:  Haskell2010

--- a/uri-templater.cabal
+++ b/uri-templater.cabal
@@ -46,6 +46,7 @@ library
                      http-types,
                      http-api-data >= 0.4.3
   hs-source-dirs:    src
+  default-language:  Haskell2010
 
 test-suite test-uri-templates
   type:              exitcode-stdio-1.0
@@ -60,6 +61,7 @@ test-suite test-uri-templates
                      prettyprinter,
                      http-api-data,
                      vector
+  default-language:  Haskell2010
 
 test-suite doctests
   type:              exitcode-stdio-1.0
@@ -68,3 +70,4 @@ test-suite doctests
   hs-source-dirs:    test
   build-depends:     base,
                      doctest >= 0.8
+  default-language:  Haskell2010

--- a/uri-templater.cabal
+++ b/uri-templater.cabal
@@ -13,7 +13,7 @@ maintainer:          ian@iankduncan.com
 copyright:           Ian Duncan
 category:            Network
 build-type:          Simple
-cabal-version:       >=1.8
+cabal-version:       >=1.10
 source-repository    head
   type:                git
   location:            https://github.com/iand675/uri-templater


### PR DESCRIPTION
## Summary
Fixes Hackage validation errors for the 1.0.0 release by updating package metadata and dependency specifications.

## Changes
- Update cabal-version from >=1.8 to >=1.10 (Hackage requirement)
- Add default-language: Haskell2010 to all components
- Add upper bounds to base dependency in test suites (base >= 4.9 && <5)
- Update copyright year to 2021-2025

These changes ensure the package can be successfully uploaded to Hackage.